### PR TITLE
Print phoenix version on boot

### DIFF
--- a/shell/.welcome.sh
+++ b/shell/.welcome.sh
@@ -1,5 +1,6 @@
 echo "Phoenix Devcontainer version: $PHOENIX_IMAGE_VERSION\n"
-echo `mix hex.info` | awk '{ print "Elixir:\t" $4 "\nOTP:\t" $6 "\n"}'
+echo `mix hex.info` | awk '{ print "Elixir:   " $4 "\nOTP:      " $6}'
+echo `mix phx.new --version` | awk '{ print "Phoenix:  " $2 "\n"}' | sed 's/v//g'
 echo "Terminal Docker tools aliases:"
 echo " * alpine: launch an interactive alpine 3.11 container"
 echo " * dive: inspect the layers of a Docker image"


### PR DESCRIPTION
Currently the Elixir and OTP versions are being printed when starting a
new shell on the container. This PR adds a command to print the phoenix
version along with the Elixir and OPT versions.